### PR TITLE
Doge: increase subunits

### DIFF
--- a/config/currencies.yml
+++ b/config/currencies.yml
@@ -537,8 +537,8 @@ doge:
   name: Dogecoin
   symbol: Ð
   alternate_symbols: []
-  subunit: Microdoge
-  subunit_to_unit: 1000000
+  subunit: Nanodoge
+  subunit_to_unit: 1000000000
   symbol_first: true
   html_entity: ''
   decimal_mark: "."


### PR DESCRIPTION
https://github.com/alfagen/kassa-admin/issues/973

## Что?

Увеличить precision для Doge: https://dogecoin.fandom.com/wiki/Dogecoin

## Чтобы что?

Чтобы при расчетах c `from_income` сумма по направлению `Doge -> Any` не округлялась до 6 знаков.