### PR TITLE
AutoRates: bestchange

### DIFF
--- a/app/models/gera/exchange_rate.rb
+++ b/app/models/gera/exchange_rate.rb
@@ -55,7 +55,12 @@ module Gera
 
     delegate  :auto_comission_by_reserve, :comission_by_base_rate, :auto_rate_by_base_from,
               :auto_rate_by_base_to, :auto_rate_by_reserve_from, :auto_rate_by_reserve_to,
+<<<<<<< HEAD
               :current_base_rate, :average_base_rate, to: :rate_comission_calculator
+=======
+              :current_base_rate, :average_base_rate, :auto_comission_from,
+              :auto_comission_to, :bestchange_delta, to: :rate_comission_calculator
+>>>>>>> 89e3389... Автослежение по курсам Беста
 
     alias_attribute :ps_from_id, :income_payment_system_id
     alias_attribute :ps_to_id, :outcome_payment_system_id
@@ -145,7 +150,11 @@ module Gera
     end
 
     def rate_comission_calculator
-      @rate_comission_calculator ||= RateComissionCalculator.new(exchange_rate: self)
+      @rate_comission_calculator ||= RateComissionCalculator.new(exchange_rate: self, external_rates: external_rates)
+    end
+
+    def external_rates
+      @external_rates ||= BestChange::Service.new(exchange_rate: self).rows
     end
   end
 end

--- a/app/models/gera/exchange_rate.rb
+++ b/app/models/gera/exchange_rate.rb
@@ -55,12 +55,8 @@ module Gera
 
     delegate  :auto_comission_by_reserve, :comission_by_base_rate, :auto_rate_by_base_from,
               :auto_rate_by_base_to, :auto_rate_by_reserve_from, :auto_rate_by_reserve_to,
-<<<<<<< HEAD
-              :current_base_rate, :average_base_rate, to: :rate_comission_calculator
-=======
               :current_base_rate, :average_base_rate, :auto_comission_from,
               :auto_comission_to, :bestchange_delta, to: :rate_comission_calculator
->>>>>>> 89e3389... Автослежение по курсам Беста
 
     alias_attribute :ps_from_id, :income_payment_system_id
     alias_attribute :ps_to_id, :outcome_payment_system_id

--- a/app/services/gera/rate_comission_calculator.rb
+++ b/app/services/gera/rate_comission_calculator.rb
@@ -4,15 +4,17 @@ module Gera
   class RateComissionCalculator
     include Virtus.model strict: true
 
+    BESTCHANGE_AUTO_COMISSION_GAP = 0.01
+
     attribute :exchange_rate
+    attribute :external_rates
 
     delegate  :auto_comission_by_base_rate?, :in_currency, :payment_system_from,
               :payment_system_to, :out_currency, :fixed_comission, to: :exchange_rate
 
     def auto_comission
-      commission = auto_comission_by_reserve
-      commission += comission_by_base_rate if auto_comission_by_base_rate?
-      commission
+      return commission unless external_rates_ready?
+      auto_comission_by_external_comissions
     end
 
     def auto_comission_by_reserve
@@ -53,6 +55,18 @@ module Gera
 
     def average_base_rate
       @average_base_rate ||= Gera::CurrencyRateHistoryInterval.where('interval_from > ?', DateTime.now.utc - 24.hours).where(cur_from_id: in_currency.local_id, cur_to_id: out_currency.local_id).average(:avg_rate)
+    end
+
+    def auto_comission_from
+      @auto_comission_from ||= auto_rate_by_reserve_from + auto_rate_by_base_from
+    end
+
+    def auto_comission_to
+      @auto_comission_to_boundary ||= auto_rate_by_reserve_to + auto_rate_by_base_to
+    end
+
+    def bestchange_delta
+      auto_comission_by_external_comissions - commission
     end
 
     private
@@ -124,6 +138,33 @@ module Gera
 
     def average(a, b)
       ((a + b) / 2.0).round(2)
+    end
+
+    def commission
+      @commission ||= begin
+        comission_percents = auto_comission_by_reserve
+        comission_percents += comission_by_base_rate if auto_comission_by_base_rate?
+        comission_percents
+      end
+    end
+
+    def external_rates_ready?
+      external_rates.present?
+    end
+
+    def auto_commision_range
+      (auto_comission_from..auto_comission_to)
+    end
+
+    def auto_comission_by_external_comissions
+      @auto_comission_by_external_comissions ||= begin
+      auto_commision_range.include?(rrate.target_rate_percent)
+        external_rates_with_similar_comissions = external_rates.select { |rate| auto_commision_range.include?(rate.target_rate_percent) }
+        return commission if external_rates_with_similar_comissions.empty?
+
+        external_rates_with_similar_comissions.sort!
+        external_rates_with_similar_comissions.last.target_rate_percent - BESTCHANGE_AUTO_COMISSION_GAP
+      end
     end
   end
 end

--- a/app/services/gera/rate_comission_calculator.rb
+++ b/app/services/gera/rate_comission_calculator.rb
@@ -153,12 +153,11 @@ module Gera
     end
 
     def auto_commision_range
-      (auto_comission_from..auto_comission_to)
+      @auto_commision_range ||= (auto_comission_from..auto_comission_to)
     end
 
     def auto_comission_by_external_comissions
       @auto_comission_by_external_comissions ||= begin
-      auto_commision_range.include?(rrate.target_rate_percent)
         external_rates_with_similar_comissions = external_rates.select { |rate| auto_commision_range.include?(rate.target_rate_percent) }
         return commission if external_rates_with_similar_comissions.empty?
 

--- a/app/services/gera/rate_comission_calculator.rb
+++ b/app/services/gera/rate_comission_calculator.rb
@@ -14,6 +14,7 @@ module Gera
 
     def auto_comission
       return commission unless external_rates_ready?
+
       auto_comission_by_external_comissions
     end
 
@@ -161,7 +162,7 @@ module Gera
         external_rates_with_similar_comissions = external_rates.select { |rate| auto_commision_range.include?(rate.target_rate_percent) }
         return commission if external_rates_with_similar_comissions.empty?
 
-        external_rates_with_similar_comissions.sort!
+        external_rates_with_similar_comissions.sort! { |a, b| a.target_rate_percent <=> b.target_rate_percent }
         external_rates_with_similar_comissions.last.target_rate_percent - BESTCHANGE_AUTO_COMISSION_GAP
       end
     end


### PR DESCRIPTION
### 3. Автослежение по курсам Беста
Это функция, которая так же всегда включена, она по сути и фиксирует финальное значение курса. 
В результате выполнения первого пункта или первого+второго пункта у нас сформировался диапазон курсов, допустим: `2.5-3.5%`. Принцип формирования финального автокурса такой:
1. Смотрим наш диапазон курсов `2.5-3.5%`
2. Смотрим курсы других обменников на бесте
3. В рамках нашего диапазона есть какие-то обменники, мы должны встать перед последним обменником в диапазоне наших курсов - то есть фактически поставить курс = 3.49%
![image](https://user-images.githubusercontent.com/40119577/137493951-b3d0dc13-8eb4-4d5d-9f29-df6c4e4cc3e3.png)
