### PR TITLE
Exchange Rate fee: set min value of -9.9

### DIFF
--- a/app/models/gera/exchange_rate.rb
+++ b/app/models/gera/exchange_rate.rb
@@ -17,6 +17,7 @@ module Gera
     include Authority::Abilities
 
     DEFAULT_COMISSION = 50
+    MIN_COMISSION = -9.9
 
     include Mathematic
     include DirectionSupport
@@ -50,6 +51,7 @@ module Gera
     end
 
     validates :commission, presence: true
+    validates :commission, numericality: { greater_than_or_equal_to: MIN_COMISSION }
 
     delegate :rate, :currency_rate, to: :direction_rate
 


### PR DESCRIPTION
https://github.com/alfagen/kassa-admin/issues/1088

## Что?

Необходимо сделать ограничение на проставку минусовых комиссий - комиссия не может быть менее -9.9%
То есть -10 уже должно выдавать ошибку
https://operator.kassa.cc/exchange_rates/1