### PR TITLE
Add enable_direction_rate_history_intervals config option

### DIFF
--- a/app/controllers/gera/direction_rate_history_intervals_controller.rb
+++ b/app/controllers/gera/direction_rate_history_intervals_controller.rb
@@ -6,6 +6,7 @@ module Gera
     authorize_actions_for DirectionRate
     helper_method :payment_system_from, :payment_system_to
     helper_method :filter
+    helper_method :history_intervals_enabled?
 
     def index
       respond_to do |format|
@@ -57,6 +58,10 @@ module Gera
       else
         raise "Unknown value_type #{filter.value_type}"
       end
+    end
+
+    def history_intervals_enabled?
+      Gera.enable_direction_rate_history_intervals
     end
   end
 end

--- a/app/jobs/gera/create_history_intervals_job.rb
+++ b/app/jobs/gera/create_history_intervals_job.rb
@@ -10,7 +10,13 @@ module Gera
     MINIMAL_DATE = Time.parse('13-07-2018 18:00')
 
     def perform
-      save_direction_rate_history_intervals if Gera::DirectionRateHistoryInterval.table_exists?
+      if Gera::DirectionRateHistoryInterval.table_exists?
+        if Gera.enable_direction_rate_history_intervals
+          save_direction_rate_history_intervals
+        else
+          logger.info 'Skipping direction_rate_history_intervals creation (disabled by config)'
+        end
+      end
       save_currency_rate_history_intervals if Gera::CurrencyRateHistoryInterval.table_exists?
     end
 

--- a/app/views/gera/direction_rate_history_intervals/index.slim
+++ b/app/views/gera/direction_rate_history_intervals/index.slim
@@ -1,5 +1,11 @@
 = render 'filter'
 
+- unless history_intervals_enabled?
+  .alert.alert-warning
+    strong Внимание!
+    |  Сбор данных для графиков направлений отключен (enable_direction_rate_history_intervals = false).
+    |  Отображаются только исторические данные.
+
 #container style="height: 400px; min-width: 310px"
 
 = javascript_include_tag 'https://code.highcharts.com/stock/highstock.js'

--- a/lib/gera/configuration.rb
+++ b/lib/gera/configuration.rb
@@ -35,6 +35,12 @@ module Gera
     @@cross_pairs = { kzt: :rub }
     @@manul_client = nil
 
+    # @param [Boolean] Включение/отключение создания direction_rate_history_intervals
+    # По умолчанию true для обратной совместимости
+    # Таблица занимает ~42GB и используется только для графиков в админке
+    mattr_accessor :enable_direction_rate_history_intervals
+    @@enable_direction_rate_history_intervals = true
+
     def cross_pairs
       h = {}
       @@cross_pairs.each do |k, v|

--- a/spec/jobs/gera/create_history_intervals_job_spec.rb
+++ b/spec/jobs/gera/create_history_intervals_job_spec.rb
@@ -15,7 +15,11 @@ module Gera
     end
 
     describe '#perform' do
-      context 'when tables exist' do
+      context 'when tables exist and enable_direction_rate_history_intervals is true' do
+        before do
+          allow(Gera).to receive(:enable_direction_rate_history_intervals).and_return(true)
+        end
+
         it 'calls save_direction_rate_history_intervals' do
           expect(DirectionRateHistoryInterval).to receive(:table_exists?).and_return(true)
           expect(CurrencyRateHistoryInterval).to receive(:table_exists?).and_return(true)
@@ -28,6 +32,26 @@ module Gera
           job.perform
 
           expect(job).to have_received(:save_direction_rate_history_intervals)
+          expect(job).to have_received(:save_currency_rate_history_intervals)
+        end
+      end
+
+      context 'when tables exist but enable_direction_rate_history_intervals is false' do
+        before do
+          allow(Gera).to receive(:enable_direction_rate_history_intervals).and_return(false)
+        end
+
+        it 'skips save_direction_rate_history_intervals but saves currency_rate_history_intervals' do
+          expect(DirectionRateHistoryInterval).to receive(:table_exists?).and_return(true)
+          expect(CurrencyRateHistoryInterval).to receive(:table_exists?).and_return(true)
+
+          job = described_class.new
+          allow(job).to receive(:save_direction_rate_history_intervals)
+          allow(job).to receive(:save_currency_rate_history_intervals)
+
+          job.perform
+
+          expect(job).not_to have_received(:save_direction_rate_history_intervals)
           expect(job).to have_received(:save_currency_rate_history_intervals)
         end
       end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe Gera::Configuration do
       expect(Gera).to respond_to(:payment_system_decorator)
     end
   end
+
+  describe '.enable_direction_rate_history_intervals' do
+    it 'defaults to true' do
+      expect(Gera.enable_direction_rate_history_intervals).to be true
+    end
+
+    it 'can be configured' do
+      original_value = Gera.enable_direction_rate_history_intervals
+      begin
+        Gera.enable_direction_rate_history_intervals = false
+        expect(Gera.enable_direction_rate_history_intervals).to be false
+      ensure
+        Gera.enable_direction_rate_history_intervals = original_value
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `enable_direction_rate_history_intervals` config option to allow disabling direction_rate_history_intervals creation
- Table occupies ~42GB on production and is only used for admin charts
- Default is `true` for backward compatibility
- When disabled, shows warning banner in the charts view

## Related
- Mercury PR: https://github.com/alfagen/mercury/pull/1748

## Test plan
- [x] Tests pass in gera (`bundle exec rspec spec/jobs/gera/create_history_intervals_job_spec.rb spec/lib/configuration_spec.rb`)
- [ ] Test with Mercury integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)